### PR TITLE
Change Event Extended attribute to default false instead of being un-settable

### DIFF
--- a/org.eventb.emf.core.edit/META-INF/MANIFEST.MF
+++ b/org.eventb.emf.core.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eventb.emf.core.edit;singleton:=true
-Bundle-Version: 1.1.0
+Bundle-Version: 1.1.1.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eventb.emf.core.provider.EventbcoreEditPlugin$Implementation
 Bundle-Vendor: %providerName
@@ -19,5 +19,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.emf.edit;bundle-version="[2.7.0,3.0.0)",
  org.eclipse.emf.ecore;bundle-version="[2.7.0,3.0.0)",
  org.eclipse.emf.ecore.edit;bundle-version="[2.7.0,3.0.0)",
- org.eventb.emf.core;bundle-version="[4.0.0,5.0.0)"
+ org.eventb.emf.core;bundle-version="[5.0.0,6.0.0)"
 Bundle-ActivationPolicy: lazy

--- a/org.eventb.emf.core/META-INF/MANIFEST.MF
+++ b/org.eventb.emf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eventb.emf.core;singleton:=true
-Bundle-Version: 4.2.1
+Bundle-Version: 5.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eventb.emf.core/model/eventbcore.ecore
+++ b/org.eventb.emf.core/model/eventbcore.ecore
@@ -170,8 +170,9 @@
     <eClassifiers xsi:type="ecore:EClass" name="Variant" eSuperTypes="#//EventBCommentedExpressionElement"/>
     <eClassifiers xsi:type="ecore:EClass" name="Event" eSuperTypes="#//EventBNamedCommentedElement">
       <eStructuralFeatures xsi:type="ecore:EAttribute" name="convergence" eType="#//machine/Convergence"/>
-      <eStructuralFeatures xsi:type="ecore:EAttribute" name="extended" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
-          unsettable="true"/>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="extended" lowerBound="1"
+          eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
+          defaultValueLiteral="false"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="refines" upperBound="-1"
           eType="#//machine/Event"/>
       <eStructuralFeatures xsi:type="ecore:EAttribute" name="refinesNames" upperBound="-1"

--- a/org.eventb.emf.core/src/org/eventb/emf/core/context/impl/ContextImpl.java
+++ b/org.eventb.emf.core/src/org/eventb/emf/core/context/impl/ContextImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.util.EDataTypeEList;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.EObjectResolvingEList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
 import org.eventb.emf.core.CorePackage;
 import org.eventb.emf.core.context.Axiom;
@@ -426,7 +427,7 @@ public class ContextImpl extends EventBNamedCommentedComponentElementImpl implem
 								 return component;
 	
 					//replace dummy URI with the proper one
-					proxy.eSetProxyURI(URI.createPlatformResourceURI(getURI().segment(1), true)
+					proxy.eSetProxyURI(URI.createPlatformResourceURI(EcoreUtil.getURI(this).segment(1), true)
 						.appendSegment(fragment)
 						.appendFileExtension(External.getString("FileExtensions.context"))
 						.appendFragment(reference));

--- a/org.eventb.emf.core/src/org/eventb/emf/core/impl/CorePackageImpl.java
+++ b/org.eventb.emf.core/src/org/eventb/emf/core/impl/CorePackageImpl.java
@@ -906,11 +906,6 @@ public class CorePackageImpl extends EPackageImpl implements CorePackage {
 		g1.getETypeArguments().add(g2);
 		initEOperation(op, g1);
 
-		op = addEOperation(eventBObjectEClass, null, "getURI", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
-		ETypeParameter t1 = addETypeParameter(op, "URI"); //$NON-NLS-1$
-		g1 = createEGenericType(t1);
-		initEOperation(op, g1);
-
 		op = addEOperation(eventBObjectEClass, this.getAnnotation(), "getAnnotation", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 		addEParameter(op, theEcorePackage.getEString(), "source", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 

--- a/org.eventb.emf.core/src/org/eventb/emf/core/machine/Event.java
+++ b/org.eventb.emf.core/src/org/eventb/emf/core/machine/Event.java
@@ -68,6 +68,7 @@ public interface Event extends EventBNamedCommentedElement {
 
 	/**
 	 * Returns the value of the '<em><b>Extended</b></em>' attribute.
+	 * The default value is <code>"false"</code>.
 	 * <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Extended</em>' attribute isn't clear,
@@ -75,11 +76,9 @@ public interface Event extends EventBNamedCommentedElement {
 	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Extended</em>' attribute.
-	 * @see #isSetExtended()
-	 * @see #unsetExtended()
 	 * @see #setExtended(boolean)
 	 * @see org.eventb.emf.core.machine.MachinePackage#getEvent_Extended()
-	 * @model unsettable="true"
+	 * @model default="false" required="true"
 	 * @generated
 	 */
 	boolean isExtended();
@@ -89,35 +88,10 @@ public interface Event extends EventBNamedCommentedElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @param value the new value of the '<em>Extended</em>' attribute.
-	 * @see #isSetExtended()
-	 * @see #unsetExtended()
 	 * @see #isExtended()
 	 * @generated
 	 */
 	void setExtended(boolean value);
-
-	/**
-	 * Unsets the value of the '{@link org.eventb.emf.core.machine.Event#isExtended <em>Extended</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #isSetExtended()
-	 * @see #isExtended()
-	 * @see #setExtended(boolean)
-	 * @generated
-	 */
-	void unsetExtended();
-
-	/**
-	 * Returns whether the value of the '{@link org.eventb.emf.core.machine.Event#isExtended <em>Extended</em>}' attribute is set.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return whether the value of the '<em>Extended</em>' attribute is set.
-	 * @see #unsetExtended()
-	 * @see #isExtended()
-	 * @see #setExtended(boolean)
-	 * @generated
-	 */
-	boolean isSetExtended();
 
 	/**
 	 * Returns the value of the '<em><b>Refines</b></em>' reference list.

--- a/org.eventb.emf.core/src/org/eventb/emf/core/machine/impl/EventImpl.java
+++ b/org.eventb.emf.core/src/org/eventb/emf/core/machine/impl/EventImpl.java
@@ -106,15 +106,6 @@ public class EventImpl extends EventBNamedCommentedElementImpl implements Event 
 	protected boolean extended = EXTENDED_EDEFAULT;
 
 	/**
-	 * This is true if the Extended attribute has been set.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	protected boolean extendedESet;
-
-	/**
 	 * The cached value of the '{@link #getRefines() <em>Refines</em>}' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -221,33 +212,8 @@ public class EventImpl extends EventBNamedCommentedElementImpl implements Event 
 	public void setExtended(boolean newExtended) {
 		boolean oldExtended = extended;
 		extended = newExtended;
-		boolean oldExtendedESet = extendedESet;
-		extendedESet = true;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, MachinePackage.EVENT__EXTENDED, oldExtended, extended, !oldExtendedESet));
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public void unsetExtended() {
-		boolean oldExtended = extended;
-		boolean oldExtendedESet = extendedESet;
-		extended = EXTENDED_EDEFAULT;
-		extendedESet = false;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.UNSET, MachinePackage.EVENT__EXTENDED, oldExtended, EXTENDED_EDEFAULT, oldExtendedESet));
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public boolean isSetExtended() {
-		return extendedESet;
+			eNotify(new ENotificationImpl(this, Notification.SET, MachinePackage.EVENT__EXTENDED, oldExtended, extended));
 	}
 
 	/**
@@ -515,7 +481,7 @@ public class EventImpl extends EventBNamedCommentedElementImpl implements Event 
 				setConvergence(CONVERGENCE_EDEFAULT);
 				return;
 			case MachinePackage.EVENT__EXTENDED:
-				unsetExtended();
+				setExtended(EXTENDED_EDEFAULT);
 				return;
 			case MachinePackage.EVENT__REFINES:
 				getRefines().clear();
@@ -550,7 +516,7 @@ public class EventImpl extends EventBNamedCommentedElementImpl implements Event 
 			case MachinePackage.EVENT__CONVERGENCE:
 				return convergence != CONVERGENCE_EDEFAULT;
 			case MachinePackage.EVENT__EXTENDED:
-				return isSetExtended();
+				return extended != EXTENDED_EDEFAULT;
 			case MachinePackage.EVENT__REFINES:
 				return refines != null && !refines.isEmpty();
 			case MachinePackage.EVENT__REFINES_NAMES:
@@ -580,7 +546,7 @@ public class EventImpl extends EventBNamedCommentedElementImpl implements Event 
 		result.append(" (convergence: "); //$NON-NLS-1$
 		result.append(convergence);
 		result.append(", extended: "); //$NON-NLS-1$
-		if (extendedESet) result.append(extended); else result.append("<unset>"); //$NON-NLS-1$
+		result.append(extended);
 		result.append(')');
 		return result.toString();
 	}

--- a/org.eventb.emf.core/src/org/eventb/emf/core/machine/impl/MachinePackageImpl.java
+++ b/org.eventb.emf.core/src/org/eventb/emf/core/machine/impl/MachinePackageImpl.java
@@ -544,7 +544,7 @@ public class MachinePackageImpl extends EPackageImpl implements MachinePackage {
 
 		initEClass(eventEClass, Event.class, "Event", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEAttribute(getEvent_Convergence(), this.getConvergence(), "convergence", null, 0, 1, Event.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEAttribute(getEvent_Extended(), ecorePackage.getEBoolean(), "extended", null, 0, 1, Event.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEAttribute(getEvent_Extended(), ecorePackage.getEBoolean(), "extended", "false", 1, 1, Event.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
 		initEReference(getEvent_Refines(), this.getEvent(), null, "refines", null, 0, -1, Event.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getEvent_RefinesNames(), ecorePackage.getEString(), "refinesNames", null, 0, -1, Event.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getEvent_Parameters(), this.getParameter(), null, "parameters", null, 0, -1, Event.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$

--- a/org.eventb.emf.feature/feature.properties
+++ b/org.eventb.emf.feature/feature.properties
@@ -26,6 +26,11 @@ description=\
 A framework which provides an EMF representation of Event-B models.\n\
 -----------------------------------------------------------------\n\
 Release history:\n\
+6.0.0\n\
+  core (5.0.0) - change extended attribute to have default false instead of being unsettable, remove deprecated getURI() method,\n\
+  edit (1.1.1) - adjust dependency for core [5.0.0,6.0.0)\n\
+  persistence (3.5.1) - adjust dependency for core [5.0.0,6.0.0), add xmb as a content type, use xmi as default for unknown file extensions,\n\
+  						avoid trying to refresh references that are unchangeable or derived.\n\
 5.4.0 \n\
   persistence (3.5.0) - add Rodin attribute priority; fix incorrect ref in itemRelations; provide 'key' constants for Rodin attributes; add 'EventBEMFUtils' class\n\
 5.3.1 \n\

--- a/org.eventb.emf.feature/feature.xml
+++ b/org.eventb.emf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eventb.emf.feature"
       label="%featureName"
-      version="5.4.0"
+      version="6.0.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/org.eventb.emf.formulas/META-INF/MANIFEST.MF
+++ b/org.eventb.emf.formulas/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Event-B Formula EMF Model
 Bundle-SymbolicName: org.eventb.emf.formulas;singleton:=true
-Bundle-Version: 1.4.0
+Bundle-Version: 1.4.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Heinrich-Heine University Dusseldorf
 Bundle-Localization: plugin
@@ -11,5 +11,5 @@ Export-Package:
  org.eventb.emf.formulas,
  org.eventb.emf.formulas.util
 Require-Bundle: org.eclipse.emf.ecore;bundle-version="[2.7.0,3.0.0)",
- org.eventb.emf.core;bundle-version="[4.2.0,5.0.0)"
+ org.eventb.emf.core;bundle-version="[5.0.0,6.0.0)"
 Bundle-ActivationPolicy: lazy

--- a/org.eventb.emf.persistence/META-INF/MANIFEST.MF
+++ b/org.eventb.emf.persistence/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.eventb.core;bundle-version="[3.0.0,4.0.0)",
  org.rodinp.core;bundle-version="[1.5.0,2.0.0)",
  org.eventb.ui;bundle-version="[3.0.0,4.0.0)",
- org.eventb.emf.core;bundle-version="[4.2.0,5.0.0)",
+ org.eventb.emf.core;bundle-version="[5.0.0,6.0.0)",
  org.eclipse.emf.ecore.xmi;bundle-version="[2.7.0,3.0.0)",
  org.eclipse.emf.transaction;bundle-version="[1.4.0,2.0.0)"
 Export-Package: org.eventb.emf.persistence,


### PR DESCRIPTION
Notes on changes in org.eventb.emf.core plugin (other plugins changed to accomodate major version increment) :-

eventbecore - attribute extended has default false and is no longer unsettable (note that operation getURI was removed in the past ready for this re-generation).

ContextImpl.java - changed eResolveProxy to avoid using getURI() method which is removed.

CorePackageImpl.java - initializePackageContents() no longer generates the getURI() method.

Event.java - generated changes related to attribute extended (removal of unsetExtended() & isSetExtended() breaks API)

EventImpl.java - generated changes related to attribute extended (removal of unsetExtended() & isSetExtended() breaks API)

MachinePackageImpl.java - generated changes related to attribute extended.