### PR TITLE
Changes resulting from reviewing translator changes

### DIFF
--- a/org.eventb.emf.persistence/src/org/eventb/emf/persistence/SaveResourcesCommand.java
+++ b/org.eventb.emf.persistence/src/org/eventb/emf/persistence/SaveResourcesCommand.java
@@ -26,13 +26,13 @@ import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.emf.workspace.AbstractEMFOperation;
 
 /**
- * Save modifiedResources using an EMF transactional command. This command can be used to save
+ * Save resources using an EMF transactional command. This command can be used to save
  * multiple EMF models. It wraps the saves in an EMF transaction 
  * (this is useful because the Rodin save may modify attributes of the source model)
  *
  * Resources must all be in the given editing domain's resource set and must be
- * marked as modified. If no collection of modifiedResources is passed, all modified
- * modifiedResources will be saved.
+ * marked as modified. If no collection of resources is passed, all modified
+ * resources will be saved.
  * 
  * @author cfs
  *
@@ -49,11 +49,11 @@ public class SaveResourcesCommand extends AbstractEMFOperation {
 	 * Resources or, if null, all modified Resources in the editing domain
 	 *
 	 * @param editingdomain
-	 * @param modifiedResources
+	 * @param resources
 	 *            to be saved (or null for all modified Resources)
 	 */
 	public SaveResourcesCommand(TransactionalEditingDomain editingDomain, Resource ... resources) {
-		super(editingDomain, "Saving Event-B EMF modifiedResources", null);
+		super(editingDomain, "Saving Event-B EMF resources", null);
 		if (resources.length == 0){
 			resources = editingDomain.getResourceSet().getResources().toArray(new Resource[0]);
 		}
@@ -87,7 +87,7 @@ public class SaveResourcesCommand extends AbstractEMFOperation {
 	@Override
 	protected IStatus doExecute(IProgressMonitor monitor, IAdaptable info) {
 		List<IStatus> status = new ArrayList<IStatus>(); //Status.OK_STATUS;
-		monitor.beginTask("Saving " + modifiedResources.size() + " modified modifiedResources", 2 * modifiedResources.size());
+		monitor.beginTask("Deleting " + deletedResources.size() + " resources", 2 * deletedResources.size());
 
 		for (final Resource resource : deletedResources) {
 			try{
@@ -99,7 +99,8 @@ public class SaveResourcesCommand extends AbstractEMFOperation {
 			}
 			monitor.worked(2);
 		}
-		
+
+		monitor.beginTask("Saving " + modifiedResources.size() + " modified resources", 2 * modifiedResources.size());
 		for (final Resource resource : modifiedResources) {
 			try{
 				resource.save(Collections.emptyMap());

--- a/org.eventb.emf.persistence/src/org/eventb/emf/persistence/factory/RodinResource.java
+++ b/org.eventb.emf.persistence/src/org/eventb/emf/persistence/factory/RodinResource.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
 import org.eventb.emf.core.EventBElement;
@@ -138,8 +139,6 @@ public class RodinResource extends XMIResourceImpl {
 						map.clear();
 						EventBElement element = syncManager.loadRodinElement(rodinFile.getRoot(), null, map, null);
 						this.getContents().add(element);
-						// syncManager.loadRodinRoot((IEventBRoot)
-						// rodinFile.getRoot(), this, null);
 					} catch (Exception e) {
 						throw new IOException("Error while loading rodin file: " + e.getLocalizedMessage());
 					}
@@ -202,7 +201,7 @@ public class RodinResource extends XMIResourceImpl {
 						}
 						rodinFile.save(null, true);
 					}
-				}, project, null);
+				}, rodinFile.getSchedulingRule() , null);
 
 			} catch (Exception e) {
 				throw new IOException("Error while saving rodin file: " + e.getLocalizedMessage());

--- a/org.eventb.emf.persistence/src/org/eventb/emf/persistence/factory/RodinResource.java
+++ b/org.eventb.emf.persistence/src/org/eventb/emf/persistence/factory/RodinResource.java
@@ -321,4 +321,39 @@ public class RodinResource extends XMIResourceImpl {
 		// does file exist?
 		return rodinFile == null ? file.exists() : rodinFile.exists();
 	}
+	
+	/**
+	 * Deletes the resource. 
+	 * This consists of 
+	 *  unloading the resource from emf and
+	 *  removing it from the containing resource set
+	 *  deleting the underlying rodin file from the rodin database
+	 *  
+	 */
+	@Override
+	public void delete(Map<?,?> options) throws IOException{
+		
+		//+++ copied from the extended XMIResourceImpl
+	    unload();
+	    ResourceSet resourceSet = getResourceSet();
+	    if (resourceSet != null) {
+	      resourceSet.getResources().remove(this);
+	    }
+		//--- end of copied from the extended XMIResourceImpl
+	    
+	    // Tell Rodin to delete the rodin file.
+	    // This is done last otherwise EMF editors see the change as a reason to ask the user if they want to reload.
+	    // It is not clear that the runnable is needed
+		try {
+			RodinCore.run(new IWorkspaceRunnable() {
+				public void run(final IProgressMonitor monitor) throws CoreException {
+					rodinFile.delete(true, null);
+				}
+			}, rodinFile.getSchedulingRule() , null);
+		} catch (RodinDBException e) {
+			throw new IOException(e);
+		}
+
+	}
+	
 }


### PR DESCRIPTION
Resource deletion should use the Rodin file deletion method so that Rodin is aware of the deletion. This prevents new not present exceptions.

Also made save command do the deletion of empty resources as discussed when reviewing translator changes.