### PR TITLE
modify code gen templates for item providers to restrict where extensions are offered 

### DIFF
--- a/org.eventb.emf.core.edit/src/org/eventb/emf/core/context/provider/ContextItemProvider.java
+++ b/org.eventb.emf.core.edit/src/org/eventb/emf/core/context/provider/ContextItemProvider.java
@@ -212,21 +212,21 @@ public class ContextItemProvider
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
-
-		newChildDescriptors.add
-			(createChildParameter
-				(ContextPackage.Literals.CONTEXT__SETS,
-				 ContextFactory.eINSTANCE.createCarrierSet()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(ContextPackage.Literals.CONTEXT__CONSTANTS,
-				 ContextFactory.eINSTANCE.createConstant()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(ContextPackage.Literals.CONTEXT__AXIOMS,
-				 ContextFactory.eINSTANCE.createAxiom()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(ContextPackage.Literals.CONTEXT__SETS,
+				 	ContextFactory.eINSTANCE.createCarrierSet()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(ContextPackage.Literals.CONTEXT__CONSTANTS,
+				 	ContextFactory.eINSTANCE.createConstant()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(ContextPackage.Literals.CONTEXT__AXIOMS,
+				 	ContextFactory.eINSTANCE.createAxiom()));
 	}
 
 }

--- a/org.eventb.emf.core.edit/src/org/eventb/emf/core/machine/provider/EventItemProvider.java
+++ b/org.eventb.emf.core.edit/src/org/eventb/emf/core/machine/provider/EventItemProvider.java
@@ -268,26 +268,26 @@ public class EventItemProvider
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
-
-		newChildDescriptors.add
-			(createChildParameter
-				(MachinePackage.Literals.EVENT__PARAMETERS,
-				 MachineFactory.eINSTANCE.createParameter()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(MachinePackage.Literals.EVENT__GUARDS,
-				 MachineFactory.eINSTANCE.createGuard()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(MachinePackage.Literals.EVENT__WITNESSES,
-				 MachineFactory.eINSTANCE.createWitness()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(MachinePackage.Literals.EVENT__ACTIONS,
-				 MachineFactory.eINSTANCE.createAction()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(MachinePackage.Literals.EVENT__PARAMETERS,
+				 	MachineFactory.eINSTANCE.createParameter()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(MachinePackage.Literals.EVENT__GUARDS,
+				 	MachineFactory.eINSTANCE.createGuard()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(MachinePackage.Literals.EVENT__WITNESSES,
+				 	MachineFactory.eINSTANCE.createWitness()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(MachinePackage.Literals.EVENT__ACTIONS,
+				 	MachineFactory.eINSTANCE.createAction()));
 	}
 	
 	/**

--- a/org.eventb.emf.core.edit/src/org/eventb/emf/core/machine/provider/MachineItemProvider.java
+++ b/org.eventb.emf.core.edit/src/org/eventb/emf/core/machine/provider/MachineItemProvider.java
@@ -260,26 +260,26 @@ public class MachineItemProvider
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
-
-		newChildDescriptors.add
-			(createChildParameter
-				(MachinePackage.Literals.MACHINE__VARIABLES,
-				 MachineFactory.eINSTANCE.createVariable()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(MachinePackage.Literals.MACHINE__INVARIANTS,
-				 MachineFactory.eINSTANCE.createInvariant()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(MachinePackage.Literals.MACHINE__VARIANT,
-				 MachineFactory.eINSTANCE.createVariant()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(MachinePackage.Literals.MACHINE__EVENTS,
-				 MachineFactory.eINSTANCE.createEvent()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(MachinePackage.Literals.MACHINE__VARIABLES,
+				 	MachineFactory.eINSTANCE.createVariable()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(MachinePackage.Literals.MACHINE__INVARIANTS,
+				 	MachineFactory.eINSTANCE.createInvariant()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(MachinePackage.Literals.MACHINE__VARIANT,
+				 	MachineFactory.eINSTANCE.createVariant()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(MachinePackage.Literals.MACHINE__EVENTS,
+				 	MachineFactory.eINSTANCE.createEvent()));
 	}
 
 }

--- a/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/AnnotationItemProvider.java
+++ b/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/AnnotationItemProvider.java
@@ -204,101 +204,101 @@ public class AnnotationItemProvider
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__DETAILS,
-				 CoreFactory.eINSTANCE.create(CorePackage.Literals.STRING_TO_STRING_MAP_ENTRY)));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 CoreFactory.eINSTANCE.createProject()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 CoreFactory.eINSTANCE.createExtension()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 CoreFactory.eINSTANCE.createAttribute()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 CoreFactory.eINSTANCE.createAnnotation()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 MachineFactory.eINSTANCE.createMachine()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 MachineFactory.eINSTANCE.createVariable()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 MachineFactory.eINSTANCE.createInvariant()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 MachineFactory.eINSTANCE.createVariant()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 MachineFactory.eINSTANCE.createEvent()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 MachineFactory.eINSTANCE.createParameter()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 MachineFactory.eINSTANCE.createGuard()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 MachineFactory.eINSTANCE.createWitness()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 MachineFactory.eINSTANCE.createAction()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 ContextFactory.eINSTANCE.createContext()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 ContextFactory.eINSTANCE.createConstant()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 ContextFactory.eINSTANCE.createCarrierSet()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 ContextFactory.eINSTANCE.createAxiom()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.ANNOTATION__CONTENTS,
-				 EcoreFactory.eINSTANCE.createEObject()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__DETAILS,
+				 	CoreFactory.eINSTANCE.create(CorePackage.Literals.STRING_TO_STRING_MAP_ENTRY)));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	CoreFactory.eINSTANCE.createProject()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	CoreFactory.eINSTANCE.createExtension()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	CoreFactory.eINSTANCE.createAttribute()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	CoreFactory.eINSTANCE.createAnnotation()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	MachineFactory.eINSTANCE.createMachine()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	MachineFactory.eINSTANCE.createVariable()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	MachineFactory.eINSTANCE.createInvariant()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	MachineFactory.eINSTANCE.createVariant()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	MachineFactory.eINSTANCE.createEvent()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	MachineFactory.eINSTANCE.createParameter()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	MachineFactory.eINSTANCE.createGuard()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	MachineFactory.eINSTANCE.createWitness()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	MachineFactory.eINSTANCE.createAction()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	ContextFactory.eINSTANCE.createContext()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	ContextFactory.eINSTANCE.createConstant()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	ContextFactory.eINSTANCE.createCarrierSet()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	ContextFactory.eINSTANCE.createAxiom()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.ANNOTATION__CONTENTS,
+				 	EcoreFactory.eINSTANCE.createEObject()));
 	}
 
 	/**

--- a/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/EventBElementItemProvider.java
+++ b/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/EventBElementItemProvider.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
@@ -239,16 +240,21 @@ public class EventBElementItemProvider
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.EVENT_BELEMENT__EXTENSIONS,
-				 CoreFactory.eINSTANCE.createExtension()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.EVENT_BELEMENT__ATTRIBUTES,
-				 CoreFactory.eINSTANCE.create(CorePackage.Literals.STRING_TO_ATTRIBUTE_MAP_ENTRY)));
+		
+			
+		if (object instanceof EObject && 
+			CorePackage.Literals.EXTENSION.getEAnnotation("org.eventb.emf.core.extendedMetaClasses") == null  || 
+			CorePackage.Literals.EXTENSION.getEAnnotation("org.eventb.emf.core.extendedMetaClasses").getReferences().contains(((EObject)object).eClass()))
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.EVENT_BELEMENT__EXTENSIONS,
+				 	CoreFactory.eINSTANCE.createExtension()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.EVENT_BELEMENT__ATTRIBUTES,
+				 	CoreFactory.eINSTANCE.create(CorePackage.Literals.STRING_TO_ATTRIBUTE_MAP_ENTRY)));
 	}
 
 }

--- a/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/EventBObjectItemProvider.java
+++ b/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/EventBObjectItemProvider.java
@@ -137,11 +137,11 @@ public class EventBObjectItemProvider
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.EVENT_BOBJECT__ANNOTATIONS,
-				 CoreFactory.eINSTANCE.createAnnotation()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.EVENT_BOBJECT__ANNOTATIONS,
+				 	CoreFactory.eINSTANCE.createAnnotation()));
 	}
 
 	/**

--- a/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/ProjectItemProvider.java
+++ b/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/ProjectItemProvider.java
@@ -149,16 +149,16 @@ public class ProjectItemProvider
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.PROJECT__COMPONENTS,
-				 MachineFactory.eINSTANCE.createMachine()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.PROJECT__COMPONENTS,
-				 ContextFactory.eINSTANCE.createContext()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.PROJECT__COMPONENTS,
+				 	MachineFactory.eINSTANCE.createMachine()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.PROJECT__COMPONENTS,
+				 	ContextFactory.eINSTANCE.createContext()));
 	}
 
 }

--- a/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/StringToAttributeMapEntryItemProvider.java
+++ b/org.eventb.emf.core.edit/src/org/eventb/emf/core/provider/StringToAttributeMapEntryItemProvider.java
@@ -177,11 +177,11 @@ public class StringToAttributeMapEntryItemProvider
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
-
-		newChildDescriptors.add
-			(createChildParameter
-				(CorePackage.Literals.STRING_TO_ATTRIBUTE_MAP_ENTRY__VALUE,
-				 CoreFactory.eINSTANCE.createAttribute()));
+		
+			newChildDescriptors.add
+				(createChildParameter
+					(CorePackage.Literals.STRING_TO_ATTRIBUTE_MAP_ENTRY__VALUE,
+				 	CoreFactory.eINSTANCE.createAttribute()));
 	}
 
 	/**

--- a/org.eventb.emf.core/model/HowToExtendTheMetaModel
+++ b/org.eventb.emf.core/model/HowToExtendTheMetaModel
@@ -55,38 +55,30 @@ Thats it! the rest is just notes about the customised code generators
 ----------------------------------------------------------------
 
 Customisations made to the Dynamic Templates (Under development)
-
-This allows the code generation to be customised so that the post-gen code changes above are not needed.
+This allows the code generation to be customised so that post-gen code changes are not needed.
 The EMF templates have been copied from org.eclipse.emf.codegen.ecore into org.eventb.emf.core
 The templates have been customised as listed below.
 
-Checklist of customisations to the code generation templates
-1)ItemProviderAdapterFactory -This obviates the need for code change 1)
+1)ItemProviderAdapterFactory
 added: (in case method of creation switch (4th clause) - n.b. this may need to be done in other clauses in this method)
 				EAnnotation annotation = <%=createClass.getQualifiedClassifierAccessor()%>.getEAnnotation("org.eventb.emf.core.extendedMetaClasses");
 				if (annotation == null  || annotation.getReferences().contains(object.eClass()))
 
-
-TBD: the mechanism 1) above works for parents in OTHER packages but it doesn't stop new children being offered all over THIS package. This is because the collectNewChildren 
-methods are hard generated code for the itemproviders of the current package - they do not use the child extenders themselves. Currently, I have customised these methods as
- shown below but this could also be done in the jet templates to make it conditional on the extendedMetaClasses annotation references.
- 
- 	/**
-	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created under this object. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
-	 * @generated NOT
-	 */
-	@Override
-	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-		super.collectNewChildDescriptors(newChildDescriptors, object);
-
-		//newChildDescriptors.add(createChildParameter(CorePackage.Literals.EVENT_BELEMENT__EXTENSIONS, RecordsFactory.eINSTANCE.createRecordCollection()));
-
-		newChildDescriptors.add(createChildParameter(RecordsPackage.Literals.RECORD_COLLECTION__RECORD_DECLARATIONS, RecordsFactory.eINSTANCE.createRecord()));
-
-		newChildDescriptors.add(createChildParameter(RecordsPackage.Literals.RECORD_COLLECTION__RECORD_EXTENSIONS, RecordsFactory.eINSTANCE
-				.createRecordExtension()));
-	}
- 
-TBD: Automatically select the correct sub package in the edit plugin childCreationExtender extension.
+2)ItemProvider - Similar to 1 but for current package rather than extensible child providers.
+		<%if ("CorePackage.Literals.EVENT_BELEMENT__EXTENSIONS".equals(createFeature.getQualifiedFeatureAccessor())) {%>
+			<%genModel.addImport("org.eventb.emf.core.EventBObject");%>
+		if (<%=createClass.getQualifiedClassifierAccessor()%>.getEAnnotation("org.eventb.emf.core.extendedMetaClasses") == null  || 
+			<%=createClass.getQualifiedClassifierAccessor()%>.getEAnnotation("org.eventb.emf.core.extendedMetaClasses").getReferences().contains(((EventBObject)object).eClass()))
+		<%}%>
+			newChildDescriptors.add
+				(createChildParameter
+					(<%=createFeature.getQualifiedFeatureAccessor()%>,
+        <%if (createClass.isMapEntry()) { %>
+				 	<%=createClass.getGenPackage().getQualifiedEFactoryInstanceAccessor()%>.create(<%=createClass.getQualifiedClassifierAccessor()%>)));
+        <%} else {%>
+				 	<%=createClass.getGenPackage().getQualifiedFactoryInstanceAccessor()%>.create<%=createClass.getName()%>()));
+        <%}%>
+        
+        
+3) TBD: Automatically select the correct sub package in the edit plugin childCreationExtender extension.
 

--- a/org.eventb.emf.core/templates/edit/ItemProvider.javajet
+++ b/org.eventb.emf.core/templates/edit/ItemProvider.javajet
@@ -365,14 +365,19 @@ public class <%=genClass.getProviderClassName()%>
       <%} else if (createFeature.isReferenceType()) { GenClass createClass = (GenClass)createClassifier;%>
 <%@ include file="ItemProvider/newChildDescriptorsReferenceFeature.override.javajetinc" fail="alternative"%>
 <%@ start %>
-
-		newChildDescriptors.add
-			(createChildParameter
-				(<%=createFeature.getQualifiedFeatureAccessor()%>,
+		<%if ("CorePackage.Literals.EVENT_BELEMENT__EXTENSIONS".equals(createFeature.getQualifiedFeatureAccessor())) {%>
+			<%genModel.addImport("org.eclipse.emf.ecore.EObject");%>
+		if (object instanceof EObject && 
+			<%=createClass.getQualifiedClassifierAccessor()%>.getEAnnotation("org.eventb.emf.core.extendedMetaClasses") == null  || 
+			<%=createClass.getQualifiedClassifierAccessor()%>.getEAnnotation("org.eventb.emf.core.extendedMetaClasses").getReferences().contains(((EObject)object).eClass()))
+		<%}%>
+			newChildDescriptors.add
+				(createChildParameter
+					(<%=createFeature.getQualifiedFeatureAccessor()%>,
         <%if (createClass.isMapEntry()) { %>
-				 <%=createClass.getGenPackage().getQualifiedEFactoryInstanceAccessor()%>.create(<%=createClass.getQualifiedClassifierAccessor()%>)));
+				 	<%=createClass.getGenPackage().getQualifiedEFactoryInstanceAccessor()%>.create(<%=createClass.getQualifiedClassifierAccessor()%>)));
         <%} else {%>
-				 <%=createClass.getGenPackage().getQualifiedFactoryInstanceAccessor()%>.create<%=createClass.getName()%>()));
+				 	<%=createClass.getGenPackage().getQualifiedFactoryInstanceAccessor()%>.create<%=createClass.getName()%>()));
         <%}%>
 <%@ include file="ItemProvider/newChildDescriptorsReferenceFeature.insert.javajetinc" fail="silent"%>
 <%@ end %><%//ItemProvider/newChildDescriptorsReferenceFeature.override.javajetinc %>


### PR DESCRIPTION
Extension elements can be annotated to restrict their parents in the edit plugins itemproviders. This was working for extending existing  packages but not for packages that 'know about'  the extension (i.e. directly reference the extension and therefore do not use extensible child providers)

Have changed the code templates and re-generated