### PR TITLE
serialised extensions use encoded attribute style for references

### DIFF
--- a/org.eventb.emf.feature/feature.properties
+++ b/org.eventb.emf.feature/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2009-2018 University of Southampton, Heinrich-Heine University Dusseldorf
+# Copyright (c) 2009-2019 University of Southampton, Heinrich-Heine University Dusseldorf
 # and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -24,6 +24,8 @@ A framework which provides an EMF representation of Event-B models.\n\
 \n\
 Release history:\n\
 -----------------------------------------------------------------\n\
+### 6.0.1 ### \n\
+  persistence (3.6.1) - serialised extensions use encoded attribute style for references\n\
 ### 6.0.0 ### \n\
   core (5.0.0) - 		upgrade to Java 1.8, \n\
     					machines may have multiple variants, \n\
@@ -219,7 +221,7 @@ Release history:\n\
  - Initial Release\n\
 
 # "copyright" property - copyright of the feature
-featureCopyright=Copyright (c) 2009-2018 University of Southampton, Heinrich-Heine University Dusseldorf and others. All rights reserved.
+featureCopyright=Copyright (c) 2009-2019 University of Southampton, Heinrich-Heine University Dusseldorf and others. All rights reserved.
 
 # "updateSiteName" property - name of the update site
 updateSiteName = Main Rodin update site

--- a/org.eventb.emf.feature/feature.xml
+++ b/org.eventb.emf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eventb.emf.feature"
       label="%featureName"
-      version="6.0.0.release"
+      version="6.0.1.qualifier"
       provider-name="%featureVendor"
       license-feature="org.rodinp.license"
       license-feature-version="1.0.0.release">

--- a/org.eventb.emf.persistence/META-INF/MANIFEST.MF
+++ b/org.eventb.emf.persistence/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.eventb.emf.persistence;singleton:=true
-Bundle-Version: 3.6.0.release
+Bundle-Version: 3.6.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.eventb.core;bundle-version="[3.0.0,4.0.0)",

--- a/org.eventb.emf.persistence/src/org/eventb/emf/persistence/factory/RodinResource.java
+++ b/org.eventb.emf.persistence/src/org/eventb/emf/persistence/factory/RodinResource.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2019 University of Southampton.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eventb.emf.persistence.factory;
 
 import java.io.IOException;
@@ -23,6 +30,7 @@ import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
 import org.eventb.emf.core.EventBElement;
 import org.eventb.emf.core.EventBObject;
@@ -160,11 +168,14 @@ public class RodinResource extends XMIResourceImpl {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public void save(final Map<?, ?> options) throws IOException {
 		if (isXmi) {
 			unresolveRefs();
-			super.save(options);
+			Map options_encoded_attributes = new HashMap( options);
+			options_encoded_attributes.put(XMIResourceImpl.OPTION_USE_ENCODED_ATTRIBUTE_STYLE, Boolean.TRUE);
+			super.save(options_encoded_attributes);
 			return;
 		} else {
 			saveAsRodin(options);

--- a/org.eventb.emf.sdk/feature.properties
+++ b/org.eventb.emf.sdk/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015-2018 University of Southampton.
+# Copyright (c) 2015-2019 University of Southampton.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,6 +25,11 @@ Event-B EMF framework. \n\
 \n\
 Release history:\n\
 -----------------------------------------------------------------\n\
+### 6.0.1 ###\n\
+- Event-B EMF Framework Feature (6.0.1)\n\
+- Event-B EMF Framework Source Feature (6.0.1): Generated\n\
+- org.eventb.emf.persistence.tests (0.0.1)\n\
+- org.eventb.emf.persistence.tests.source (0.0.1): Generated\n\
 ### 6.0.0 ###\n\
 - Event-B EMF Framework Feature (6.0.0)\n\
 - Event-B EMF Framework Source Feature (6.0.0): Generated\n\
@@ -37,7 +42,7 @@ Release history:\n\
 - org.eventb.emf.persistence.tests.source (0.0.1): Generated\n\
   
 # "copyright" property - copyright of the feature
-featureCopyright=Copyright (c) 2009-2018 University of Southampton, Heinrich-Heine University Dusseldorf and others. All rights reserved.
+featureCopyright=Copyright (c) 2009-2019 University of Southampton, Heinrich-Heine University Dusseldorf and others. All rights reserved.
 
 # "updateSiteName" property - name of the update site
 updateSiteName = Main Rodin update site

--- a/org.eventb.emf.sdk/feature.xml
+++ b/org.eventb.emf.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eventb.emf.sdk"
       label="%featureName"
-      version="6.0.0.release"
+      version="6.0.1.qualifier"
       provider-name="%featureVendor"
       license-feature="org.rodinp.license"
       license-feature-version="1.0.0.release">


### PR DESCRIPTION
use encoded attribute style for serialised extensions to ensure that references work correctly