### PR TITLE
Added a method for getResource (create if necessary) for EMFRodinDB

### DIFF
--- a/org.eventb.emf.persistence.tests/src/org/eventb/emf/persistence/tests/ChannelEMFSetup.java
+++ b/org.eventb.emf.persistence.tests/src/org/eventb/emf/persistence/tests/ChannelEMFSetup.java
@@ -407,8 +407,7 @@ public class ChannelEMFSetup {
 		// act5: channel := {}
 		// END
 		EO_init = EventBEMFUtils.createEvent(domain, EOMch,
-				IEvent.INITIALISATION);
-		EO_init.setExtended(true);
+				IEvent.INITIALISATION, true);
 		EO_init_act_3 = EventBEMFUtils.createAction(domain, EO_init, "act3",
 				"sents ≔ ∅");
 		EO_init_act_4 = EventBEMFUtils.createAction(domain, EO_init, "act4",
@@ -427,8 +426,7 @@ public class ChannelEMFSetup {
 		// act2: sents(s_count + 1) := msg
 		// act3: channel := channel \/ {s_count + 1}
 		// END
-		EO_sends = EventBEMFUtils.createEvent(domain, EOMch, "sends");
-		EO_sends.setExtended(true);
+		EO_sends = EventBEMFUtils.createEvent(domain, EOMch, "sends", true);
 		EventBEMFUtils.createRefinesEventClause(domain, EO_sends, "sends");
 		EO_sends_grd_2 = EventBEMFUtils.createGuard(domain, EO_sends, "grd2",
 				"card(channel) ≠ max_size", false);
@@ -516,16 +514,14 @@ public class ChannelEMFSetup {
 		// STATUS ordinary
 		// END
 		EOIO_init = EventBEMFUtils.createEvent(domain, EOIOMch,
-				IEvent.INITIALISATION);
-		EOIO_init.setExtended(true);
+				IEvent.INITIALISATION, true);
 
 		// sends
 		// extended
 		// STATUS ordinary
 		// REFINES sends
 		// END
-		EOIO_sends = EventBEMFUtils.createEvent(domain, EOIOMch, "sends");
-		EOIO_sends.setExtended(true);
+		EOIO_sends = EventBEMFUtils.createEvent(domain, EOIOMch, "sends", true);
 		EventBEMFUtils.createRefinesEventClause(domain, EOIO_sends, "sends");
 
 		// receives
@@ -538,8 +534,7 @@ public class ChannelEMFSetup {
 		// THEN
 		// ...
 		// END
-		EOIO_receives = EventBEMFUtils.createEvent(domain, EOIOMch, "receives");
-		EOIO_receives.setExtended(true);
+		EOIO_receives = EventBEMFUtils.createEvent(domain, EOIOMch, "receives", true);
 		EventBEMFUtils.createRefinesEventClause(domain, EOIO_receives,
 				"receives");
 		EOIO_receives_grd_2 = EventBEMFUtils.createGuard(domain, EOIO_receives,

--- a/org.eventb.emf.persistence/META-INF/MANIFEST.MF
+++ b/org.eventb.emf.persistence/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.eventb.emf.persistence;singleton:=true
-Bundle-Version: 3.6.1.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.eventb.core;bundle-version="[3.0.0,4.0.0)",

--- a/org.eventb.emf.persistence/src/org/eventb/emf/persistence/EMFRodinDB.java
+++ b/org.eventb.emf.persistence/src/org/eventb/emf/persistence/EMFRodinDB.java
@@ -196,10 +196,13 @@ public final class EMFRodinDB {
 	}
 
 	/**
-	 * loads an Event-B component (URI) as an EMF Resource
+	 * Loads a EMF resource given its URI.
 	 *
-	 * @param root
-	 * @return
+	 * @param fileURI the input URI.
+	 * 
+	 * @return the resource loaded into the containing resource set or
+	 *         <code>null</code> if the loading fails, e.g., when the file does
+	 *         not exist.
 	 */
 	public Resource loadResource(URI fileURI) {
 		Resource resource = resourceSet.getResource(fileURI, false); //n.b. do not load until notifications disabled
@@ -214,12 +217,28 @@ public final class EMFRodinDB {
 				resource.load(Collections.emptyMap());
 				// TODO throw exception instead (break API)
 			} catch (IOException e) {
-				// @htson exception occurs when the resource does not exist
-				// In this case, return the resource
-				return resource;
+				return null;
 			} finally {
 				resource.eSetDeliver(deliver);
 			}
+		}
+		return resource;
+	}
+
+	/**
+	 * Utility method to get the resource from the file URI.
+	 * 
+	 * @param fileURI the URI of the file
+	 * 
+	 * @return the resource corresponding to the input URI. If the resource is
+	 *         already contained in the resource set, it is returned. Otherwise,
+	 *         a new resource is created for the input URI in the resource set.
+	 * @since 3.7
+	 */
+	public Resource getResource(URI fileURI) {
+		Resource resource = resourceSet.getResource(fileURI, false);
+		if (resource == null) {
+			resource = resourceSet.createResource(fileURI);
 		}
 		return resource;
 	}

--- a/org.eventb.emf.persistence/src/org/eventb/emf/persistence/EMFRodinDB.java
+++ b/org.eventb.emf.persistence/src/org/eventb/emf/persistence/EMFRodinDB.java
@@ -202,27 +202,26 @@ public final class EMFRodinDB {
 	 * @return
 	 */
 	public Resource loadResource(URI fileURI) {
-		Resource resource = null;
-		resource = resourceSet.getResource(fileURI, false); //n.b. do not load until notifications disabled
+		Resource resource = resourceSet.getResource(fileURI, false); //n.b. do not load until notifications disabled
 		if (resource == null) {
-			// @htson return the newly created resource, do not try to load.
 			resource = resourceSet.createResource(fileURI);
-			return resource;
-		} else {
-			if (!resource.isLoaded()) {
-				boolean deliver = resource.eDeliver();
-				resource.eSetDeliver(false); // turn off notifications while loading
-				try {
-					resource.load(Collections.emptyMap());
-					// TODO throw exception instead (break API)
-				} catch (IOException e) {
-					return null;
-				} finally {
-					resource.eSetDeliver(deliver);
-				}
-			}
-			return resource;
 		}
+		// Try to load the resource
+		if (!resource.isLoaded()) {
+			boolean deliver = resource.eDeliver();
+			resource.eSetDeliver(false); // turn off notifications while loading
+			try {
+				resource.load(Collections.emptyMap());
+				// TODO throw exception instead (break API)
+			} catch (IOException e) {
+				// @htson exception occurs when the resource does not exist
+				// In this case, return the resource
+				return resource;
+			} finally {
+				resource.eSetDeliver(deliver);
+			}
+		}
+		return resource;
 	}
 
 	/**

--- a/org.eventb.emf.persistence/src/org/eventb/emf/persistence/EMFRodinDB.java
+++ b/org.eventb.emf.persistence/src/org/eventb/emf/persistence/EMFRodinDB.java
@@ -203,31 +203,25 @@ public final class EMFRodinDB {
 	 */
 	public Resource loadResource(URI fileURI) {
 		Resource resource = null;
-		try {
-			resource = resourceSet.getResource(fileURI, false); //n.b. do not load until notifications disabled
-			if (resource == null) {
-				resource = resourceSet.createResource(fileURI);
-			}
-		} catch (Exception e) {
-			System.out.println("Unable to load resource for " + fileURI + "\n" + e.getMessage());
-			return null;
-		}
-		if (!resource.isLoaded()) {
-			boolean deliver = resource.eDeliver();
-			resource.eSetDeliver(false); // turn off notifications while loading
-			try {
-				resource.load(Collections.emptyMap());
-			} catch (IOException e) {
-				return null;
-			} finally {
-				resource.eSetDeliver(deliver);
-			}
-
-		}
-		if (resource.isLoaded()) {
+		resource = resourceSet.getResource(fileURI, false); //n.b. do not load until notifications disabled
+		if (resource == null) {
+			// @htson return the newly created resource, do not try to load.
+			resource = resourceSet.createResource(fileURI);
 			return resource;
 		} else {
-			return null;
+			if (!resource.isLoaded()) {
+				boolean deliver = resource.eDeliver();
+				resource.eSetDeliver(false); // turn off notifications while loading
+				try {
+					resource.load(Collections.emptyMap());
+					// TODO throw exception instead (break API)
+				} catch (IOException e) {
+					return null;
+				} finally {
+					resource.eSetDeliver(deliver);
+				}
+			}
+			return resource;
 		}
 	}
 


### PR DESCRIPTION
When trying loading a non-existing resource, return the newly created resource immediatly rather than trying to load it from the disk.
